### PR TITLE
AOT compilation compatibility fix

### DIFF
--- a/src/app/shared/component/smd-datatable/datatable.component.ts
+++ b/src/app/shared/component/smd-datatable/datatable.component.ts
@@ -4,8 +4,7 @@ import {
     ViewEncapsulation,
     Input,
     Output,
-    Inject,
-    forwardRef,
+    Injector,
     EventEmitter,
     DoCheck,
     IterableDiffers,
@@ -131,11 +130,14 @@ export class SmdDataTableCellComponent implements OnInit, OnDestroy {
     `
 })
 export class SmdDataTableRowComponent {
+    private _parent: SmdDataTable;
+
     @Input() row: SmdDataRowModel;
     @Input() renderCheckbox: boolean;
     @Input() columns: SmdDataTableColumnComponent[];
 
-    constructor(@Inject(forwardRef(() => SmdDataTable)) private _parent: SmdDataTable, private dialog: MdDialog, private viewContainerRef: ViewContainerRef) {
+    constructor(injector: Injector, private dialog: MdDialog, private viewContainerRef: ViewContainerRef) {
+        this._parent = injector.get(SmdDataTable);
     }
 
     _onClick(column: SmdDataTableColumnComponent, model: any) {
@@ -234,10 +236,13 @@ export class SmdDataTableColumnComponent implements OnInit {
     `
 })
 export class SmdDatatableActionButton {
+    private _parent: SmdDataTable;
+
     @Input() label: string;
     @Output() onClick: EventEmitter<void> = new EventEmitter<void>();
 
-    constructor(@Inject(forwardRef(() => SmdDataTable)) private _parent: SmdDataTable) {
+    constructor(injector: Injector) {
+        this._parent = injector.get(SmdDataTable);
     }
 
     _onButtonClick(event: Event) {
@@ -260,12 +265,15 @@ export class SmdDatatableActionButton {
     `
 })
 export class SmdContextualDatatableButton {
+    private _parent: SmdDataTable;
+
     @Input() icon: string;
     @Input() minimunSelected: number = -1;
     @Input() maxSelected: number = -1;
     @Output() onClick: EventEmitter<any[]> = new EventEmitter<any[]>();
 
-    constructor(@Inject(forwardRef(() => SmdDataTable)) private _parent: SmdDataTable) {
+    constructor(injector: Injector) {
+        this._parent = injector.get(SmdDataTable);
     }
 
     _onButtonClick(event: Event) {
@@ -308,6 +316,7 @@ export class SmdContextualDatatableButton {
     }
 })
 export class SmdDatatableHeader implements AfterContentInit, OnDestroy {
+    private _parent: SmdDataTable;
 
     private filterTimeout: any;
     public filterValue: string;
@@ -320,7 +329,8 @@ export class SmdDatatableHeader implements AfterContentInit, OnDestroy {
     @ContentChildren(SmdDatatableActionButton) actionButtons: QueryList<SmdDatatableActionButton>;
     @ContentChildren(SmdContextualDatatableButton) contextualButtons: QueryList<SmdContextualDatatableButton>;
 
-    constructor(@Inject(forwardRef(() => SmdDataTable)) private _parent: SmdDataTable) {
+    constructor(injector: Injector) {
+        this._parent = injector.get(SmdDataTable);
     }
 
     public shouldRenderCheckbox() {

--- a/src/app/shared/component/smd-fab-speed-dial/fab-speed-dial.ts
+++ b/src/app/shared/component/smd-fab-speed-dial/fab-speed-dial.ts
@@ -7,8 +7,7 @@ import {
     AfterContentInit,
     ElementRef,
     Renderer,
-    Inject,
-    forwardRef,
+    Injector,
     ContentChildren,
     QueryList,
     ContentChild,
@@ -26,6 +25,7 @@ const Z_INDEX_ITEM: number = 23;
     `
 })
 export class SmdFabSpeedDialTrigger {
+    private _parent: SmdFabSpeedDialComponent;
 
     /**
      * Whether this trigger should spin (360dg) while opening the speed dial
@@ -33,7 +33,8 @@ export class SmdFabSpeedDialTrigger {
     @HostBinding('class.smd-spin')
     @Input() spin: boolean = false;
 
-    constructor(@Inject(forwardRef(() => SmdFabSpeedDialComponent)) private _parent: SmdFabSpeedDialComponent) {
+    constructor(injector: Injector) {
+        this._parent = injector.get(SmdFabSpeedDialComponent);
     }
 
     @HostListener('click', ['$event'])
@@ -53,10 +54,12 @@ export class SmdFabSpeedDialTrigger {
     `
 })
 export class SmdFabSpeedDialActions implements AfterContentInit {
+    private _parent: SmdFabSpeedDialComponent;
 
     @ContentChildren(MdButton) _buttons: QueryList<MdButton>;
 
-    constructor(@Inject(forwardRef(() => SmdFabSpeedDialComponent)) private _parent: SmdFabSpeedDialComponent, private renderer: Renderer) {
+    constructor(injector: Injector, private renderer: Renderer) {
+        this._parent = injector.get(SmdFabSpeedDialComponent);
     }
 
     ngAfterContentInit(): void {


### PR DESCRIPTION
Changed the speed dial and datatable components to drop the dependency on forwardRef, which had been breaking AOT compilation in my project.

(Note: my project doesn't use the datatable, just the speed dial, so my testing only covered the speed dial. I don't see why this change would cause a functionality regression in the data table when the speed dial continued to work as intended, but probably worth testing anyway before you merge this. It's also entirely possible that other AOT-breaking issues exist in the datatable component, as I've only confirmed that the speed dial AOT compiles successfully.)

Also, thanks a lot for taking the time to make this! smd-fab-speed-dial filled in the last remaining gap before I could finally start porting my project from a custom UpgradeModule-based Material1 wrapper to Material2.